### PR TITLE
Add cli arguments for main branch name and path

### DIFF
--- a/.changeset/cyan-vans-hear.md
+++ b/.changeset/cyan-vans-hear.md
@@ -1,0 +1,6 @@
+---
+"changeset-recover": minor
+---
+
+Added cli argument for main branch name `-m`
+Added cli argument for project path `-b`

--- a/src/bin.js
+++ b/src/bin.js
@@ -11,16 +11,27 @@ yargs(hideBin(process.argv))
     ['$0'],
     'Generate changesets based on merges to the default branch',
     (yargs) => {
-      return yargs.option('base', {
-        alias: 'b',
-        type: 'string',
-        description: `The base reference to calculate changes from. By default this is the most recent tag. This can be used to backfill changes, or test out the tool before comitting to a release.`,
-      });
+      return yargs
+        .option('base', {
+          alias: 'b',
+          type: 'string',
+          description: `The base reference to calculate changes from. By default this is the most recent tag. This can be used to backfill changes, or test out the tool before comitting to a release.`,
+        })
+        .option('main', {
+          alias: 'm',
+          type: 'string',
+          description: `The main/master branch to calculate changes from. By default this is the most recent main. Legacy projects might still use master.`,
+        })
+        .option('path', {
+          alias: 'p',
+          type: 'string',
+          description: `The path to the project root. By default this is the current working directory.`,
+        });
     },
     async (args) => {
-      let changes = await getGroupedChanges(args.base);
+      let changes = await getGroupedChanges(args.base, args.main, args.path);
 
-      await startInteractive(changes);
+      await startInteractive(changes, args.path);
     }
   )
   .help()

--- a/src/changesets.js
+++ b/src/changesets.js
@@ -4,9 +4,13 @@ import path from 'node:path';
 /**
  * @param {import('./types.js').GroupedChange} change}
  */
-export async function writeChangeset(change) {
+export async function writeChangeset(change, cwd = process.cwd()) {
   let publicPackages = change.workspaces.filter((project) => !project.private);
-  let filePath = path.join('.changeset', `automated-from-${change.commit}.md`);
+  let filePath = path.join(
+    cwd,
+    '.changeset',
+    `automated-from-${change.commit}.md`
+  );
 
   let message = change.message;
 

--- a/src/git/author.js
+++ b/src/git/author.js
@@ -2,28 +2,32 @@ import { execaCommand } from 'execa';
 
 /**
  * @param {string} commitSha
+ * @param {string} cwd current working directory, defaults to process.cwd()
  */
-export async function isRenovate(commitSha) {
-  let author = await authorOf(commitSha);
+export async function isRenovate(commitSha, cwd = process.cwd()) {
+  let author = await authorOf(commitSha, cwd);
 
   return authorIs.renovate(author);
 }
 
 /**
  * @param {string} commitSha
+ * @param {string} cwd current working directory, defaults to process.cwd()
  */
-export async function isDependabot(commitSha) {
-  let author = await authorOf(commitSha);
+export async function isDependabot(commitSha, cwd = process.cwd()) {
+  let author = await authorOf(commitSha, cwd);
 
   return authorIs.dependabot(author);
 }
 
 /**
  * @param {string} commitSha
+ * @param {string} cwd current working directory, defaults to process.cwd()
  */
-export async function authorOf(commitSha) {
+export async function authorOf(commitSha, cwd = process.cwd()) {
   let { stdout: author } = await execaCommand(
-    `git show -s --format='%an' ${commitSha}`
+    `git show -s --format='%an' ${commitSha}`,
+    { cwd }
   );
 
   return author.replace(/'/g, '');

--- a/src/git/commits.js
+++ b/src/git/commits.js
@@ -2,59 +2,76 @@ import { execaCommand } from 'execa';
 
 /**
  * @param {string} mergeSha
+ * @param {string} [ baseBranch ]
+ * @param {string} [ cwd ]
  */
-export async function commitsForMerge(mergeSha) {
+export async function commitsForMerge(
+  mergeSha,
+  baseBranch = 'main',
+  cwd = process.cwd()
+) {
   // This currently includes the history before the branch started,
   // so this is excessive
   // await execaCommand(`git log -m ${mergeSha}`);
 
   // last line + 1 is the number of commits to print
-  await execaCommand(`git rev-list --no-merges --count main ^${mergeSha}`);
+  await execaCommand(
+    `git rev-list --no-merges --count ${baseBranch} ^${mergeSha}`,
+    { cwd }
+  );
 
   let numCommits = 0;
 
-  await execaCommand(`git log ${mergeSha} -${numCommits + 1}`);
+  await execaCommand(`git log ${mergeSha} -${numCommits + 1}`, { cwd });
 }
 
 /**
  * @param {string} sinceTag
  * @param {string} [ branch ]
+ * @param {string} [ cwd ]
  */
-export async function mergesToBranch(sinceTag, branch = 'main') {
+export async function mergesToBranch(
+  sinceTag,
+  branch = 'main',
+  cwd = process.cwd()
+) {
   // https://stackoverflow.com/a/47213799/356849
   //  --first-parent
   //    skips commits from merged branches. This removes the entries where someone merged master into their branches.
   //  --merges
   //   shows only "merge commits" (commits with more than 1 parent). Omit this argument if you want to see direct commits to your main branch.
   let { stdout } = await execaCommand(
-    `git log ${sinceTag}..${branch} --first-parent --format='%H'`
+    `git log ${sinceTag}..${branch} --first-parent --format='%H'`,
+    { cwd }
   );
 
   return stdout.replace(new RegExp(`'`, 'g'), '').split('\n');
 }
 
 /**
+ * @param {string} [ cwd ]
  * @returns {Promise<string>}
  */
-export async function getLatestTag() {
+export async function getLatestTag(cwd = process.cwd()) {
   // Examples:
   //   ember-resources@5.6.2
   //  (same output as git tag -l)
-  let { stdout: tag } = await execaCommand(`git describe --abbrev=0`);
+  let { stdout: tag } = await execaCommand(`git describe --abbrev=0`, { cwd });
 
   return tag;
 }
 
 /**
  * @param {string} mergeSha
+ * @param {string} [ cwd ]
  * @returns {Promise<string[]>} repo-relative file paths that were changed in the merge-commit
  */
-export async function filesChangedIn(mergeSha) {
+export async function filesChangedIn(mergeSha, cwd = process.cwd()) {
   // --pretty=
   //   is a git-hack to remove all the commit details because in this case we only care about the files
   let { stdout } = await execaCommand(
     `git log -m -1 --name-only --pretty= ${mergeSha}`,
-    { cwd: process.cwd() }
+    { cwd }
   );
 
   return stdout.split('\n');
@@ -62,10 +79,13 @@ export async function filesChangedIn(mergeSha) {
 
 /**
  * @param {string} sha
+ * @param {string} [ cwd ]
  * @returns {Promise<string>}
  */
-export async function messageOf(sha) {
-  let { stdout } = await execaCommand(`git log --format=%B -n 1 ${sha}`);
+export async function messageOf(sha, cwd = process.cwd()) {
+  let { stdout } = await execaCommand(`git log --format=%B -n 1 ${sha}`, {
+    cwd,
+  });
 
   return stdout;
 }

--- a/src/git/paths.js
+++ b/src/git/paths.js
@@ -1,7 +1,11 @@
 import { execaCommand } from 'execa';
 
-export async function gitRoot() {
-  let { stdout } = await execaCommand(`git rev-parse --show-toplevel`);
+/**
+ * @param {string} cwd current working directory, defaults to process.cwd()
+ * @returns {Promise<string>}
+ */
+export async function gitRoot(cwd = process.cwd()) {
+  let { stdout } = await execaCommand(`git rev-parse --show-toplevel`, { cwd });
 
   return stdout;
 }

--- a/src/github.js
+++ b/src/github.js
@@ -1,9 +1,9 @@
 import { Octokit } from '@octokit/core';
 import { execaCommand } from 'execa';
 
-export async function getMergedPRs() {
+export async function getMergedPRs(cwd = process.cwd()) {
   let octokit = new Octokit();
-  let { org, repo } = await getOwner();
+  let { org, repo } = await getOwner(cwd);
 
   if (!org || !repo) {
     return [];
@@ -32,12 +32,15 @@ export function extractPRNumberFromCommitMessage(message) {
 }
 
 /**
+ * @param {string} cwd current working directory, defaults to process.cwd()
  * @returns {Promise<{ org?: string | undefined; repo?: string | undefined}>}
  */
-export async function getOwner() {
+export async function getOwner(cwd = process.cwd()) {
   // ❯ git config --get remote.origin.url
   // git@github.com:embroider-build/embroider.git
-  let { stdout } = await execaCommand('git config --get remote.origin.url');
+  let { stdout } = await execaCommand('git config --get remote.origin.url', {
+    cwd,
+  });
 
   let match = /github\.com:(?<org>[^/]+)\/(?<repo>[^.]+)\.git/.exec(stdout);
 

--- a/src/interactive.js
+++ b/src/interactive.js
@@ -6,8 +6,9 @@ import { formatMessage, selectMerges } from './select-merges.js';
 
 /**
  * @param {import('./types.js').GroupedChange[]} changes
+ * @param {string} [ cwd ] defaults to process.cwd()
  */
-export async function startInteractive(changes) {
+export async function startInteractive(changes, cwd = process.cwd()) {
   let selected = await selectMerges(changes);
 
   if (selected.length === 0) {
@@ -37,7 +38,7 @@ export async function startInteractive(changes) {
 
   if (answers.proceedToChangesets) {
     for (let change of selected) {
-      await writeChangeset(change);
+      await writeChangeset(change, cwd);
     }
   }
 }


### PR DESCRIPTION
Depends on https://github.com/NullVoxPopuli/ember-apply/pull/435

Adds cli argument to specify name of main branch (for example `master` for legacy projects that haven't yet migrated to main).
Also adds option to specify path to project so you can execute changeset-recover from any other working directory (useful when tweaking this project).

Fixes #3 